### PR TITLE
feat: Add Git tag that tracks the Docker edge tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,3 +44,14 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
+  tag:
+    name: Update Git tag
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: edge
+          message: Update to reflect the published Docker edge tag


### PR DESCRIPTION
This commit fixes #18 by adding a Git tag that tracks the Docker edge tag. This tag is updated after the Docker image is published.

I decided to use a tag for this instead of a branch because we aren't concerned with history. We only need a reference to the commit used to build the Docker edge tag.