### PR TITLE
fix: Switch to synchronizing a branch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,14 +44,15 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
-  tag:
-    name: Update Git tag
+  sync-branche:
+    name: Synchronize Git branch
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: rickstaa/action-create-tag@v1
+      - uses: connor-baer/action-sync-branch@main
         with:
-          tag: edge
-          message: Update to reflect the published Docker edge tag
+          branch: edge
+          token: ${{ secrets.GITHUB_TOKEN }}
+          force: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,7 @@ runtimes:
     - node@16.14.2
 actions:
   enabled:
-    #- trunk-fmt-pre-commit
-    #- trunk-check-pre-push
-    #- commitlint
+    - trunk-fmt-pre-commit
+    - trunk-check-pre-push
+    - commitlint
     - trunk-upgrade-available

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,7 @@ runtimes:
     - node@16.14.2
 actions:
   enabled:
-    - trunk-fmt-pre-commit
-    - trunk-check-pre-push
-    - commitlint
+    #- trunk-fmt-pre-commit
+    #- trunk-check-pre-push
+    #- commitlint
     - trunk-upgrade-available


### PR DESCRIPTION
This change modifies the workflow to synchronize a branch instead of updating a tag, since Codespaces prebuilds do not support tags. The `edge` branch will be used to trigger the prebuild.