### PR TITLE
feat: Run `trunk upgrade` when a Trunk is detected

### DIFF
--- a/.devcontainer/bin/update_content.sh
+++ b/.devcontainer/bin/update_content.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# If a Trunk configuration directory exists, upgrade Trunk (functionally
+# initializing the tool for the first time in this workspace)
+if test -d ./.trunk; then
+    trunk upgrade
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "image": "ghcr.io/nomirose/devcontainer:edge",
   "remoteUser": "root",
+  "updateContentCommand": ".devcontainer/bin/update_content.sh",
   "customizations": {
     "vscode": {
       "settings": {},

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,7 @@ runtimes:
     - node@16.14.2
 actions:
   enabled:
-    - trunk-fmt-pre-commit
-    - trunk-check-pre-push
-    - commitlint
+    # - trunk-fmt-pre-commit
+    # - trunk-check-pre-push
+    # - commitlint
     - trunk-upgrade-available


### PR DESCRIPTION
By implementing this as an `updateContentCommand` script, the results will be cached by the Codespace prebuilds.

Additionally, disable Git hooks for now as they seem to be broken, preventing committing or pushing.