### PR TITLE
build: switch to `update-content.sh`, allow direnv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
     "dockerfile": "Dockerfile"
   },
   "remoteUser": "root",
-  "postStartCommand": [
-    "./.devcontainer/post-start.sh",
+  "updateContentCommand": [
+    "./.devcontainer/update-content.sh",
     "${containerWorkspaceFolder}"
   ],
   "customizations": {

--- a/.devcontainer/update-content.sh
+++ b/.devcontainer/update-content.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-# Run after the devcontainer has successfully started
+# Run whenever the contents of the workspace mount are updated
 # https://containers.dev/implementors/json_reference/#lifecycle-scripts
 
 workspace_dir="${1:=}"
@@ -16,3 +16,6 @@ fi
 whoami="$(whoami)"
 sudo chown -R "${whoami}" "${workspace_dir}"
 sudo setfacl -bnR "${workspace_dir}"
+
+# Allow direnv to load `.envrc` files in the workspace mount
+direnv allow "${workspace_dir}"


### PR DESCRIPTION
I switched to using a `update-content.sh` script, which is run at an earlier stage in the container setup process. This runs the `direnv allow` command before the VS Code extensions are loaded, preventing a warning about the workspace directory not being allowed.